### PR TITLE
Corners and intersection fixed in the board

### DIFF
--- a/bash2048.sh
+++ b/bash2048.sh
@@ -58,11 +58,11 @@ function print_board {
   printf "$header pieces=$pieces target=$target score=$score\n"
   printf "Board status:\n" >&3
   printf "\n"
-  printf '/------'
+  printf '╔------'
   for l in $(_seq 1 $index_max); do
-    printf '|------'
+    printf '+------'
   done
-  printf '\\\n'
+  printf '╗\n'
   for l in $(_seq 0 $index_max); do
     printf '|'
     for m in $(_seq 0 $index_max); do
@@ -81,17 +81,17 @@ function print_board {
     let l==$index_max || {
       printf '\n|------'
       for l in $(_seq 1 $index_max); do
-        printf '|------'
+        printf '+------'
       done
       printf '|\n'
       printf '\n' >&3
     }
   done
-  printf '\n\\------'
+  printf '\n╚------'
   for l in $(_seq 1 $index_max); do
-    printf '|------'
+    printf '+------'
   done
-  printf '/\n'
+  printf '╝\n'
 }
 
 # Generate new piece on the board


### PR DESCRIPTION
Instead of forward and backward slash in the corners, and Pipe in the intersections, I have replaced with corner characters and '+' for intersection. 

Board looks much better.
![bash2048-screenshot](https://cloud.githubusercontent.com/assets/1309805/3157986/31f860ca-eafd-11e3-99d0-1007f7e785ab.png)
