### PR TITLE
os x bugfix converting seconds into a duration

### DIFF
--- a/bash2048.sh
+++ b/bash2048.sh
@@ -265,8 +265,14 @@ function end_game {
   print_board
   printf "Your score: $score\n"
   
-  printf "This game lasted " 
-  date -u -d @${total_time} +%T
+  printf "This game lasted "
+
+  `date --version > /dev/null 2>&1`
+  if [[ "$?" -eq 0 ]]; then
+      date -u -d @${total_time} +%T
+  else
+      date -u -r ${total_time} +%T
+  fi
   
   stty echo
   let $1 && {


### PR DESCRIPTION
Removed whitespace after `printf` and updated the date command to also work on OS X.