### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "./bash2048.sh"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 Bash implementation of popular 2048 game.
 Controlled with arrow keys.
 
+[![Run on Repl.it](https://repl.it/badge/github/mydzor/bash2048)](https://repl.it/github/mydzor/bash2048)
+
 Bugs: https://github.com/mydzor/bash2048/issues


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@MrEconomical/bash2048).